### PR TITLE
Update version bounds/format cabal file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *~
 dist/
+dist-newstyle/
+cabal.project.local
 cabal.sandbox.config
+.cabal-sandbox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,49 +1,65 @@
-dist: trusty
-sudo: false
-os: linux
+env:
+ # Note: We have to use Cabal 2.4 with GHC 7.0 since for some reason
+ # builds of "text" fail with GHC 7.0 and Cabal versions prior to 2.4
+ # https://github.com/haskell/bytestring/issues/213
+ # With Cabal 2.4 we also get improved syntax in cabal.project files,
+ # supporting remote sources, and other goodies, so use it across the
+ # board.
+ - GHCVER=7.4.2 CABALVER=2.4
+ - GHCVER=7.6.3 CABALVER=2.4
+ - GHCVER=7.8.4 CABALVER=2.4
+ - GHCVER=7.10.3 CABALVER=3.2
+ - GHCVER=8.0.2 CABALVER=3.2
+ - GHCVER=8.2.2 CABALVER=3.2
+ - GHCVER=8.4.4 CABALVER=3.2
+ - GHCVER=8.6.5 CABALVER=3.2
+ - GHCVER=8.8.3 CABALVER=3.2
+ - GHCVER=8.10.1 CABALVER=3.2
+
+ ### The head in "ppa", currently 8.7, is no longer worth testing.
+ # - GHCVER=head  CABALVER=2.4
 
 language: haskell
+
 cache:
   directories:
-    - .cabal-sandbox
+    - $HOME/.cabal/packages
+    - $HOME/.cabal/store
 
 matrix:
-  include:
-  - ghc: "8.10"
-    env: CACHE_NAME=CACHE8.10
-    install : cabal sandbox init && cabal install --only-dependencies --enable-tests --disable-documentation
-    script: cabal configure --enable-tests && cabal test --show-details=always
+  allow_failures:
+   - env: GHCVER=head  CABALVER=2.4
 
-  - ghc: "8.8"
-    env: CACHE_NAME=CACHE8.8
-    install : cabal sandbox init && cabal install --only-dependencies --enable-tests --disable-documentation
-    script: cabal configure --enable-tests && cabal test --show-details=always
+before_install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+ - cabal --version
+ - "GHCNUMVER=$(ghc --numeric-version|perl -ne '/^(\\d+)\\.(\\d+)\\.(\\d+)(\\.(\\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')"
+ - echo $GHCNUMVER
 
-  - ghc: "8.6"
-    env: CACHE_NAME=CACHE8.6
+install:
+ - travis_retry cabal v2-update
 
-  - ghc: "8.4"
-    env: CACHE_NAME=CACHE8.4
-
-  - ghc: "8.2"
-    env: CACHE_NAME=CACHE8.2
-
-  - ghc: "8.0"
-    env: CACHE_NAME=CACHE8.0
-
-  - ghc: "7.10"
-    env: CACHE_NAME=CACHE7.10
-
-  - ghc: "7.8"
-    env: CACHE_NAME=CACHE7.8
-
-  - ghc: "7.6"
-    env: CACHE_NAME=CACHE7.6
-
-  - ghc: "7.4"
-    env: CACHE_NAME=CACHE7.4
-    install : cabal sandbox init && cabal install --only-dependencies --enable-tests --disable-documentation
-    script: cabal configure --enable-tests && cabal test --show-details=always
-
-install : cabal sandbox init && cabal install --only-dependencies --enable-tests --enable-benchmarks --disable-documentation
-script: cabal configure --enable-tests --enable-benchmarks && cabal test --show-details=always && cabal bench --benchmark-option="-obench.html"
+script:
+ - cabal v2-configure
+ - cabal v2-build
+ - cabal v2-haddock -O0
+ - cabal v2-sdist -o .
+ - cabal v2-test
+ # Remove to enable build of sdist.
+ - rm -f cabal.project
+ # Build the benchmarks and run a single iteration.
+ - if [ "$GHCNUMVER" -ge 71000 ]; then
+      (cabal v2-bench -O0);
+   fi
+ - cabal check
+ - export SRC=$(cabal info . | awk '{print $2; exit}');
+   if [ -f "$SRC.tar.gz" ]; then
+      cabal get "./$SRC.tar.gz";
+      (cd "$SRC"; cabal v2-build);
+   else
+      echo "expected '$SRC.tar.gz' not found";
+      exit 1;
+   fi

--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ Library provides the functions to find unique and duplicate elements in the list
 [![Hackage version](https://img.shields.io/hackage/v/Unique.svg?label=Hackage)](https://hackage.haskell.org/package/Unique) 
 [![Stackage version](https://www.stackage.org/package/Unique/badge/lts?label=Stackage)](https://www.stackage.org/package/Unique)
 [![Build Status](https://travis-ci.org/kapralVV/Unique.svg?branch=master)](https://travis-ci.org/kapralVV/Unique)
+
+cabal file formatted and versions updated with `cabal-edit upgradeall`

--- a/Unique.cabal
+++ b/Unique.cabal
@@ -1,86 +1,76 @@
-name:                Unique
+cabal-version: 2.0
+name:          Unique
+version:       0.4.7.7
+license:       BSD3
+license-file:  LICENSE
+maintainer:    ualinuxcn@gmail.com
+author:        Volodymyr Yashchenko
+tested-with:   ghc >=7.4 && <8.2.1 || >8.2.1 && <8.12
+synopsis:      It provides the functionality like unix "uniq" utility
+description:
+    Library provides the functions to find unique and duplicate elements in the list
 
-version:             0.4.7.7
-
-synopsis:            It provides the functionality like unix "uniq" utility
-description:         Library provides the functions to find unique and duplicate elements in the list
-license:             BSD3
-license-file:        LICENSE
-author:              Volodymyr Yashchenko
-maintainer:          ualinuxcn@gmail.com
-category:            Data
-build-type:          Simple
-cabal-version:       >=1.10
-tested-with:    GHC == 8.10
-	      , GHC == 8.8
-              , GHC == 8.6
-              , GHC == 8.4
-              , GHC == 8.2
-              , GHC == 8.0
-              , GHC == 7.8
-              , GHC == 7.6
-              , GHC == 7.4
+category:      Data
+build-type:    Simple
 
 source-repository head
-   type:             git
-   location:         https://github.com/kapralVV/Unique.git
+    type:     git
+    location: https://github.com/kapralVV/Unique.git
 
 library
-  exposed-modules:      Data.List.Unique,
-                        Data.List.UniqueStrict,
-                        Data.List.UniqueUnsorted
+    exposed-modules:
+        Data.List.Unique
+        Data.List.UniqueStrict
+        Data.List.UniqueUnsorted
 
-  build-depends:         base                 >= 4.0 && < 5
-                       , containers           >= 0.5.0 && < 0.7
-                       , extra                >= 1.6.2 && < 1.7
-                       , hashable             >= 1.2.6 && < 1.4
-                       , unordered-containers >= 0.2.8 && < 0.3
+    default-language: Haskell2010
+    ghc-options:      -Wall
+    build-depends:
+        base >=4.0 && <=4.15,
+        containers >=0.5.0.0 && <=0.7,
+        extra >=1.6.2 && <=1.8,
+        hashable >= 1.2.6 && <=1.4,
+        unordered-containers >= 0.2.8 && <=0.3
 
-  default-language:    Haskell2010
-  ghc-options:         -Wall
+test-suite HspecTest
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   tests
+    other-modules:
+        Unique.Complex
+        Unique.IsUnique
+        Unique.RepeatedBy
+        Unique.SortUniq
+        Unique.AllUnique
+        UniqueStrict.IsUnique
+        UniqueStrict.RepeatedBy
+        UniqueStrict.SortUniq
+        UniqueStrict.AllUnique
+        UniqueUnsorted.IsUnique
+        UniqueUnsorted.RemoveDuplicates
+        UniqueUnsorted.RepeatedBy
+        UniqueUnsorted.AllUnique
 
+    default-language: Haskell2010
+    ghc-options:      -Wall
+    build-depends:
+        base >=4.0 && <5,
+        Unique,
+        hspec -any,
+        containers >=0.5.0.0 && <=0.7,
+        QuickCheck    >= 2.10 && <2.15
 
-Test-Suite HspecTest
-  type:                exitcode-stdio-1.0
-  hs-source-dirs:      tests
-  main-is:             Main.hs
-
-  other-modules:       Unique.Complex
-                     , Unique.IsUnique
-                     , Unique.RepeatedBy
-                     , Unique.SortUniq
-                     , Unique.AllUnique
-                     , UniqueStrict.IsUnique
-                     , UniqueStrict.RepeatedBy
-                     , UniqueStrict.SortUniq
-                     , UniqueStrict.AllUnique
-                     , UniqueUnsorted.IsUnique
-                     , UniqueUnsorted.RemoveDuplicates
-                     , UniqueUnsorted.RepeatedBy
-                     , UniqueUnsorted.AllUnique
-
-
-  build-depends:       base          >= 4.0 && < 5
-                     , hspec
-                     , containers    >= 0.5.0 && < 0.7
-                     , QuickCheck    >= 2.10 && <2.15
-                     , Unique
-
-  default-language:    Haskell2010
-  ghc-options:        -Wall
-
-Benchmark Criterion
-  type:                exitcode-stdio-1.0
-  hs-source-dirs:      bench
-  main-is:             Main.hs
-
-  build-depends:       base          >= 4.0 && < 5
-                     , Unique
-                     , criterion
-                     , QuickCheck    >= 2.10 && <2.15
-                     , quickcheck-instances
-                     , bytestring
-                     , hashable
-
-  default-language:    Haskell2010
-  ghc-options:        -Wall -rtsopts
+benchmark Criterion
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:      -Wall -rtsopts
+    build-depends:
+        base >=4.0 && <5,
+        Unique,
+        criterion -any,
+        QuickCheck    >= 2.10 && <2.15,
+        quickcheck-instances -any,
+        bytestring -any,
+        hashable -any


### PR DESCRIPTION
update .gitignore for cabal v2 commands
add note to README.md about cabal-edit upgradeall

fixes: https://github.com/kapralVV/Unique/issues/5

I used a [shell.nix](https://gist.github.com/Kiwi/aa483a99779c67b5eb8489ed4e9223d0) like this for ghc 8.10.1 and 8.8.4 and did the various cabal build/bench/test for v1 and v2 (as far as I know I did them all) successfully
