### PR TITLE
Allow building with base-4.15.0.0 (GHC 9.0)

### DIFF
--- a/Unique.cabal
+++ b/Unique.cabal
@@ -26,7 +26,7 @@ library
     default-language: Haskell2010
     ghc-options:      -Wall
     build-depends:
-        base >=4.0 && <=4.15,
+        base >=4.0 && <=4.16,
         containers >=0.5.0.0 && <=0.7,
         extra >=1.6.2 && <=1.8,
         hashable >= 1.2.6 && <=1.4,


### PR DESCRIPTION
I am able to build `Unique` and successfully run its tests with this change.