### PR TITLE
Support hashable >=^ 1.4, improve unit tests.

### DIFF
--- a/Unique.cabal
+++ b/Unique.cabal
@@ -29,7 +29,7 @@ library
         base >=4.0 && < 5,
         containers >=0.5.0.0 && <=0.7,
         extra >=1.6.2 && <=1.8,
-        hashable >= 1.2.6 && <=1.4,
+        hashable >= 1.2.6 && < 1.5,
         unordered-containers >= 0.2.8 && <=0.3
 
 test-suite HspecTest

--- a/tests/UniqueStrict/RepeatedBy.hs
+++ b/tests/UniqueStrict/RepeatedBy.hs
@@ -15,7 +15,7 @@ repeatedByTests =
     repeatedBy (>100) ( [] :: [Int] ) `shouldBe` []
 
   it "repeatedBy: simple test" $ do
-    repeatedBy (>2) "This is the test line" `shouldBe` " eist"
+    sort (repeatedBy (>2) "This is the test line") `shouldBe` " eist"
 
   it "repeatedBy: returns [] when predicate (=< negative) " $
     property $
@@ -39,7 +39,7 @@ repeatedByTests =
   it "repeatedBy: resulted elements should occur only once" $
     property $
     \ x xs -> x > 0
-              ==> all (==1) . map length . group $ repeatedBy (> x) ( xs :: String )
+              ==> all ((==1) . length) . group $ repeatedBy (> x) ( xs :: String )
 
   it "unique: simple test" $ do
     unique  "foo bar" `shouldBe` " abfr"

--- a/tests/UniqueUnsorted/RemoveDuplicates.hs
+++ b/tests/UniqueUnsorted/RemoveDuplicates.hs
@@ -4,7 +4,7 @@ import Test.Hspec
 import Test.QuickCheck
 
 import Data.List.UniqueUnsorted
-import Data.List (group)
+import Data.List (group, sort)
 
 
 removeDuplicatesTests :: SpecWith ()
@@ -15,7 +15,7 @@ removeDuplicatesTests =
     removeDuplicates ( [] :: [Int] ) `shouldBe` []
 
   it "removeDuplicates: simple test" $ do
-    removeDuplicates "foo bar" `shouldBe` " abrfo"
+    sort (removeDuplicates "foo bar") `shouldBe` " abfor"
 
   it "removeDuplicates: multiple execution should return the same result" $
     property $
@@ -27,4 +27,4 @@ removeDuplicatesTests =
 
   it "removeDuplicates: elements should occur only once #2" $
     property $
-    \ xs -> all (==1) . map length . group $ removeDuplicates ( xs :: [Integer] )
+    \ xs -> all ((==1) . length) . group $ removeDuplicates ( xs :: [Integer] )

--- a/tests/UniqueUnsorted/RepeatedBy.hs
+++ b/tests/UniqueUnsorted/RepeatedBy.hs
@@ -4,7 +4,7 @@ import Test.Hspec
 import Test.QuickCheck
 
 import Data.List.UniqueUnsorted
-import Data.List (group)
+import Data.List (group, sort)
 
 
 repeatedByTests :: SpecWith ()
@@ -15,7 +15,7 @@ repeatedByTests =
     repeatedBy (>100) ( [] :: [Int] ) `shouldBe` []
 
   it "repeatedBy: simple test" $ do
-    repeatedBy (>2) "This is the test line" `shouldBe` " stei"
+    sort (repeatedBy (>2) "This is the test line") `shouldBe` " eist"
 
   it "repeatedBy: returns [] when predicate (=< negative) " $
     property $
@@ -29,10 +29,10 @@ repeatedByTests =
   it "repeatedBy: resulted elements should occur only once" $
     property $
     \ x xs -> x > 0
-              ==> all (==1) . map length . group $ repeatedBy (> x) ( xs :: String )
+              ==> all ((==1) . length) . group $ repeatedBy (> x) ( xs :: String )
 
   it "unique: simple test" $ do
-    unique  "foo bar" `shouldBe` " abrf"
+    sort (unique  "foo bar") `shouldBe` " abfr"
 
   it "repeated: simple test" $ do
     repeated  "foo bar" `shouldBe` "o"


### PR DESCRIPTION
- [x] Expand upper version bound for `hashable` dependecy to include recent versions.
- [x] Fix failing tests by making them order-insensitive.

https://hackage.haskell.org/package/hashable-1.4.1.0/changelog

Closes #9 